### PR TITLE
Add more API endpoints 

### DIFF
--- a/Changes
+++ b/Changes
@@ -11,4 +11,5 @@
   - validate_id_token
   - get_consent_request
   - accept_consent_request
+  - revoke_login_sessions
   

--- a/Changes
+++ b/Changes
@@ -1,6 +1,4 @@
 {{$NEXT}}
-
-0.001     2024-09-12 11:15:49+00:00 UTC
   - Initial release
   - get_login_request
   - accept_login_request
@@ -8,6 +6,8 @@
   - accept_logout_request
   - exchange_token
   - fetch_jwks
+  - fetch_openid_configuration
+  - validate_token
   - validate_id_token
   - get_consent_request
   - accept_consent_request

--- a/Changes
+++ b/Changes
@@ -12,4 +12,3 @@
   - get_consent_request
   - accept_consent_request
   - revoke_login_sessions
-  

--- a/lib/WebService/Hydra/Client.pm
+++ b/lib/WebService/Hydra/Client.pm
@@ -13,7 +13,7 @@ use WebService::Hydra::Exception;
 use Syntax::Keyword::Try;
 
 use constant OK_STATUS_CODE          => 200;
-use constant OK_EMPTY_STATUS_CODE    => 201;
+use constant OK_NO_CONTENT_CODE    => 204;
 use constant BAD_REQUEST_STATUS_CODE => 400;
 
 our $VERSION = '0.01';
@@ -455,7 +455,7 @@ method revoke_login_sessions (%args) {
     $path .= "?$query" if $query;
 
     my $result = $self->api_call($method, $path);
-    if ($result->{code} != OK_EMPTY_STATUS_CODE) {
+    if ($result->{code} != OK_NO_CONTENT_CODE) {
         WebService::Hydra::Exception::RevokeLoginSessionsFailed->new(
             message  => "Failed to revoke login sessions",
             category => "client",

--- a/lib/WebService/Hydra/Client.pm
+++ b/lib/WebService/Hydra/Client.pm
@@ -13,6 +13,7 @@ use WebService::Hydra::Exception;
 use Syntax::Keyword::Try;
 
 use constant OK_STATUS_CODE          => 200;
+use constant OK_EMPTY_STATUS_CODE    => 201;
 use constant BAD_REQUEST_STATUS_CODE => 400;
 
 our $VERSION = '0.01';
@@ -372,5 +373,32 @@ method accept_consent_request ($consent_challenge, $params) {
     }
     return $result->{data};
 }
+
+
+
+=head2 revoke_login_sessions
+
+This endpoint invalidates authentication sessions.
+It expects a user ID (subject) and invalidates all sessions for this user. or session ID (sid) and invalidates the session.
+
+=cut
+
+method revoke_login_sessions (%args) {
+    my $method = "DELETE";
+    my $path   = "$admin_endpoint/admin/oauth2/auth/sessions/login";
+    
+    my $query  = join('&', map { "$_=$args{$_}" } keys %args);
+    $path .= "?$query" if $query;
+
+    my $result = $self->api_call($method, $path);
+    if ($result->{code} != OK_EMPTY_STATUS_CODE) {
+        WebService::Hydra::Exception::RevokeLoginSessionsFailed->new(
+            message  => "Failed to revoke login sessions",
+            category => "client",
+            details  => $result
+        )->throw;
+    }
+    return $result->{data};
+} 
 
 1;

--- a/lib/WebService/Hydra/Client.pm
+++ b/lib/WebService/Hydra/Client.pm
@@ -19,6 +19,7 @@ use constant BAD_REQUEST_STATUS_CODE => 400;
 our $VERSION = '0.01';
 
 field $http;
+field $jwks;
 field $admin_endpoint :param :reader;
 field $public_endpoint :param :reader;
 
@@ -73,6 +74,16 @@ Return HTTP object.
 
 method http {
     return $http //= HTTP::Tiny->new();
+}
+
+=head2 jwks
+
+return jwks object
+
+=cut
+
+method jwks {
+    return $jwks //= $self->fetch_jwks();
 }
 
 =head2 api_call
@@ -309,7 +320,6 @@ Decodes the id_token and validates its signature against Hydra and returns the d
 =cut
 
 method validate_id_token ($id_token) {
-    my $jwks = $self->fetch_jwks();
     try {
         my $payload = decode_jwt(
             token    => $id_token,

--- a/lib/WebService/Hydra/Exception.pm
+++ b/lib/WebService/Hydra/Exception.pm
@@ -105,6 +105,7 @@ my @all_exceptions = qw(
     InvalidIdToken
     InvalidConsentChallenge
     InternalServerError
+    RevokeLoginSessionsFailed
 );
 
 =head2 import

--- a/lib/WebService/Hydra/Exception/InvalidLoginRequest.pm
+++ b/lib/WebService/Hydra/Exception/InvalidLoginRequest.pm
@@ -6,7 +6,7 @@ use Object::Pad;
 ## VERSION
 
 class WebService::Hydra::Exception::InvalidLoginRequest :isa(WebService::Hydra::Exception) {
-    
+    field $redirect_to :param :reader = undef;
 
     sub BUILDARGS {
         my ($class, %args) = @_;

--- a/lib/WebService/Hydra/Exception/RevokeLoginSessionsFailed.pm
+++ b/lib/WebService/Hydra/Exception/RevokeLoginSessionsFailed.pm
@@ -1,0 +1,20 @@
+package WebService::Hydra::Exception::RevokeLoginSessionsFailed;
+use strict;
+use warnings;
+use Object::Pad;
+
+## VERSION
+
+class WebService::Hydra::Exception::RevokeLoginSessionsFailed :isa(WebService::Hydra::Exception) {
+    
+    sub BUILDARGS {
+        my ($class, %args) = @_;
+        
+        $args{message}  //= 'Failed to revoke login sessions';
+        $args{category} //= 'client';
+        
+        return %args;
+    }
+}
+
+1;

--- a/t/unit/hydra_client.t
+++ b/t/unit/hydra_client.t
@@ -406,7 +406,7 @@ subtest 'revoke_login_sessions' => sub {
 
     # Test for 200 OK status code
     $mock_api_response = {
-        code => 201,
+        code => 204,
         data => undef};
     my $got = $client->revoke_login_sessions(subject => '1234');
 

--- a/t/unit/hydra_client.t
+++ b/t/unit/hydra_client.t
@@ -388,6 +388,67 @@ subtest 'accept_logout_request' => sub {
     dies_ok { $client->accept_logout_request("VALID_CHALLENGE") } 'Dies if http request fails for some reason';
 };
 
+subtest 'revoke_login_sessions' => sub {
+    my $mock_hydra = Test::MockModule->new('WebService::Hydra::Client');
+    my $mock_api_response;
+    my @params;
+    $mock_hydra->redefine(
+        'api_call',
+        sub {
+            (@params) = @_;
+            return $mock_api_response;
+        });
+
+    my $client = WebService::Hydra::Client->new(
+        admin_endpoint  => 'http://dummyhydra.com/admin',
+        public_endpoint => 'http://dummyhydra.com'
+    );
+
+    # Test for 200 OK status code
+    $mock_api_response = {
+        code => 201,
+        data => undef};
+    my $got = $client->revoke_login_sessions(subject => '1234');
+
+    is $params[1], 'DELETE', 'DELETE request method';
+    is $params[2], 'http://dummyhydra.com/admin/admin/oauth2/auth/sessions/login?subject=1234',
+        'Request URL built with correct parameters';
+    is_deeply $got , $mock_api_response->{data}, 'api_call response correctly parsed';
+    
+    @params = ();
+    my $got = $client->revoke_login_sessions(sid => '1234');
+
+    is $params[1], 'DELETE', 'DELETE request method';
+    is $params[2], 'http://dummyhydra.com/admin/admin/oauth2/auth/sessions/login?sid=1234',
+        'Request URL built with correct parameters';
+    is_deeply $got , $mock_api_response->{data}, 'api_call response correctly parsed';
+
+    # Test for other non-200 status codes
+    $mock_api_response = {
+        code => 401,
+        data => {
+            error             => "string",
+            error_description => "string",
+            status_code       => 401
+        }};
+    dies_ok { $client->revoke_login_sessions(subject => "invalid") } 'Dies if non-200 status code is received from api_call';
+    my $exception          = $@;
+    my $expected_exception = WebService::Hydra::Exception::RevokeLoginSessionsFailed->new(
+        message  => 'Failed to revoke login sessions',
+        category => 'client',
+        details  => $mock_api_response
+    );
+    is_deeply $exception , $expected_exception, 'Return api_call response for Non 200 status code';
+
+    $mock_hydra->redefine(
+        'api_call',
+        sub {
+            die "Request to http://dummyhydra.com/admin/oauth2/auth/requests/consent/accept?challenge=VALID_CHALLENGE failed - Network issue";
+        });
+
+    dies_ok { $client->accept_logout_request("VALID_CHALLENGE") } 'Dies if http request fails for some reason';
+};
+
 done_testing();
 
 1;


### PR DESCRIPTION
# Description
Adding the following endpoints:
1- SSO sessions reovoke `admin/oauth2/auth/sessions/login`
2- Fetch openid configuration `.well-known/openid-configuration`

Adding `validate_token` subroutine and adding cahing for fetching jwks.
